### PR TITLE
設定作成フォームのテンプレート側でのユーザー情報の入力方法を改良。設定更新画面のエラー処理の内容を変更（他の設定名と同一にならないようにす…

### DIFF
--- a/travel/test/integtest/accounts/test_login.py
+++ b/travel/test/integtest/accounts/test_login.py
@@ -1,4 +1,3 @@
-from time import sleep
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
@@ -26,7 +25,7 @@ class MySeleniumTests(StaticLiveServerTestCase):
         o.add_argument('--no-sandbox')
         o.add_argument('--window-size=1200x600')
         cls.selenium = webdriver.Chrome(chromedriver_path, options=o)
-        cls.selenium.implicitly_wait(15)
+        cls.selenium.implicitly_wait(5)
 
     @classmethod
     def tearDownClass(cls):
@@ -38,7 +37,6 @@ class MySeleniumTests(StaticLiveServerTestCase):
         ログイン画面にアクセスし、必要なフォーム入力し、ログインボタンを押す
         """
         self.selenium.get('%s%s' % (self.live_server_url, '/accounts/login/'))
-        sleep(5)
         # ページソースを確認
         print(self.selenium.page_source)
         username_input = self.selenium.find_element_by_name("username")
@@ -48,7 +46,6 @@ class MySeleniumTests(StaticLiveServerTestCase):
         self.selenium.find_element_by_xpath(
             '/html/body/div/div/div/form/div[3]/button').click()
 
-        sleep(5)
         # ページソースを確認
         print(self.selenium.page_source)
         result = self.selenium.current_url

--- a/travel/test/unittest/common/test_data.py
+++ b/travel/test/unittest/common/test_data.py
@@ -326,6 +326,26 @@ class SettingCorrectTestData1st(TestCase):
         )
 
 
+class SettingCorrectTestData2ndUser1st(TestCase):
+    """
+    設定の正常データのセットアップその１の２
+    ユーザーは上記と同一
+    """
+    databases = '__all__'
+
+    @classmethod
+    def setUp(cls):
+        Setting.objects.create(
+            id=COR_SETTING_DATA_2nd["id"],
+            user=AppUser.objects.get(
+                id=COR_SETTING_DATA_1st["user"]),
+            name=COR_SETTING_DATA_2nd["name"],
+            radius=COR_SETTING_DATA_2nd["radius"],
+            max_show_num=COR_SETTING_DATA_2nd["max_show_num"],
+        )
+
+
+
 class SettingCorrectTestData2nd(TestCase):
     """
     設定の正常データのセットアップその２

--- a/travel/test/unittest/travel/test_form.py
+++ b/travel/test/unittest/travel/test_form.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from django.test import TestCase
 from django import forms
 
@@ -6,8 +8,10 @@ from travel.forms import SettingForm, SettingUpdateForm
 from test.unittest.common.test_data import (
     COR_APPUSER_DATA_1st,
     COR_SETTING_DATA_1st,
+    COR_SETTING_DATA_2nd,
     AppUserCorrectTestData1st,
     SettingCorrectTestData1st,
+    SettingCorrectTestData2ndUser1st,
 )
 
 
@@ -23,7 +27,7 @@ class MockSettingForm(SettingForm):
 
 class SettingFormTestcase(TestCase):
     """
-    設定情報の一覧画面のテスト
+    設定登録画面用のフォームのテスト
     """
     databases = '__all__'
 
@@ -46,15 +50,39 @@ class SettingFormTestcase(TestCase):
         self.assertEqual(result, expect)
 
 
+class MockSettingUpdateFormWithInstance(SettingForm):
+    """
+    設定フォームのcleaned_dataの値を事前に用意しておく
+    """
+    cleaned_data = {
+        'user': COR_APPUSER_DATA_1st['id'],
+        'name': COR_SETTING_DATA_1st['name'],
+    }
+    # ユーザー１の設定情報２つめ
+    instance = Mock()
+    instance.name.return_value = COR_SETTING_DATA_2nd['name']
+
+
+class MockSettingUpdateForm(SettingForm):
+    """
+    設定フォームのcleaned_dataの値を事前に用意しておく
+    """
+    cleaned_data = {
+        'user': COR_APPUSER_DATA_1st['id'],
+        'name': COR_SETTING_DATA_1st['name'],
+    }
+
+
 class SettingUpdateFormTestcase(TestCase):
     """
-    設定情報の一覧画面のテスト
+    設定更新画面用のフォームのテスト
     """
     databases = '__all__'
 
     def setUp(self):
         AppUserCorrectTestData1st.setUp()
         SettingCorrectTestData1st.setUp()
+        SettingCorrectTestData2ndUser1st.setUp()
 
     def test_class_meta_variable__is_registered_correctly(self):
         meta = SettingUpdateForm(Setting).Meta()
@@ -62,3 +90,17 @@ class SettingUpdateFormTestcase(TestCase):
         self.assertEqual(meta.model, Setting)
         self.assertEqual(meta.fields, fields)
         self.assertIsInstance(meta.widgets['user'], forms.HiddenInput)
+
+    def test_clean__when_old_new_setting_name_same(self):
+        msf = MockSettingForm(instance=Setting)
+        msf.clean()
+        # エラーがないのでKeyErrorとなる
+        with self.assertRaises(KeyError):
+            msf.errors['name'][0]
+
+    def test_clean__when_old_new_setting_name_different(self):
+        msf = MockSettingUpdateFormWithInstance(instance=Setting)
+        msf.clean()
+        result = msf.errors['name'][0]
+        expect = '同じ設定名が存在します。違う設定名に変更してください。'
+        self.assertEqual(result, expect)

--- a/travel/travel/forms.py
+++ b/travel/travel/forms.py
@@ -34,3 +34,16 @@ class SettingUpdateForm(forms.ModelForm):
         widgets = {
             'user': forms.HiddenInput(),
         }
+
+    def clean(self):
+        super().clean()
+        user = self.cleaned_data.get('user', None)
+        new_setting_name = self.cleaned_data.get('name', None)
+        old_setting_name = self.instance.name
+        # 他の設定に設定名が使われていた場合
+        if not new_setting_name == old_setting_name:
+            try:
+                Setting.objects.get(user=user, name=new_setting_name)
+                self.add_error('name', '同じ設定名が存在します。違う設定名に変更してください。')
+            except Setting.DoesNotExist:
+                pass

--- a/travel/travel/templates/travel/setting_form.html
+++ b/travel/travel/templates/travel/setting_form.html
@@ -17,7 +17,7 @@
               {% endif %}
               <div class="col">
               <label>設定名</label>
-              {{ form.user }}
+              <input type="hidden" name="user" id="id_user" value={{ user_id }}>
               {{ form.name }}
               {{ form.name.errors }}
               </div>
@@ -36,17 +36,5 @@
         </div>
     </div>
 </div>
-
-<script>
-  // NOTE: 本来はViewやformでする処理だが、
-  // セッション情報の渡し方がなさそうなためjQueryでフォームにユーザーIDを入れている。
-  // ユーザーIDはuuidのため、他のユーザーから推測される心配はない。
-  jQuery(function ($) {
-    $(function(){
-      $("#id_user").val("{{ user_id }}");
-    });
-  });
-</script>
-
 
 {% endblock content %}


### PR DESCRIPTION
…る。）。統合テストの待ち時間設定を短縮。